### PR TITLE
Mistake in example

### DIFF
--- a/rules/all-unique-arguments.md
+++ b/rules/all-unique-arguments.md
@@ -20,7 +20,7 @@ The incoming values are assigned to the arguments in the same order than in the 
 <?php
 
 function f($a, $b, $a) {
-	echo $a;
+	echo $b.$a;
 }
 
 f('e', 'f', 'g'); // prints 'fg'


### PR DESCRIPTION
the example on line 23 would print 'g' not 'fg'
