### PR TITLE
Update __autoload to use include

### DIFF
--- a/rules/use-smart-autoload.md
+++ b/rules/use-smart-autoload.md
@@ -9,7 +9,7 @@ When it was introduced, class autoloading was build around the function `__autol
 // example of __autoload
 function __autoload($classname) {
     $filename = "./". $classname .".php";
-    include_once($filename);
+    include($filename);
 }
 
 ?>


### PR DESCRIPTION
__autoload() it's called only if the class don't exist
