### PR TITLE
Update __autoload

### DIFF
--- a/rules/use-smart-autoload.md
+++ b/rules/use-smart-autoload.md
@@ -9,9 +9,7 @@ When it was introduced, class autoloading was build around the function `__autol
 // example of __autoload
 function __autoload($classname) {
     $filename = PROJECT_ROOT.'/'. $classname .'.php';
-    if (file_exists($filename)) {
-	    include($filename);
-	}
+    include($filename);
 }
 
 ?>


### PR DESCRIPTION
Not necessary here, there is only one __autoload() , if fail will have another error with class don't exist.
It's only necessary if you try more than 1 $filename sequentially in the __autoload.
