### PR TITLE
Typo on line 91

### DIFF
--- a/rules/no-useless-unset.md
+++ b/rules/no-useless-unset.md
@@ -88,7 +88,7 @@ function foo() {
 	unset($this->property);
 	
 	foreach($array as $key => $value) {
-		unset($array[$value]);
+		unset($array[$key]);
 	}
 }
 


### PR DESCRIPTION
This code:
    foreach($array as $key => $value) {
        unset($array[$value]);
    }
Should say:
    foreach($array as $key => $value) {
        unset($array[$key]);
    }
