### PR TITLE
Derick Rethans github link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Acknowledgements
 ClearPHP was originally written by Damien Seguy. The following people have contributed to this project:
 
 <!-- contributors -->
-* Derick Rethans (https://github.com/kitsched)
+* Derick Rethans (https://github.com/derickr)
 * fneuneu (https://github.com/Fneufneu)
 * Gary Jones (https://github.com/GaryJones)
 * Guillaume Deviart (https://github.com/GuillaumeDievart)


### PR DESCRIPTION
The link to Derick Rethans github has changed or was incorrect. Corrected now.